### PR TITLE
Avoid saving during table refresh

### DIFF
--- a/main_suiviclientpro.py
+++ b/main_suiviclientpro.py
@@ -327,29 +327,35 @@ class SuiviClientPro(QMainWindow):
 
     def update_table(self):
 
-        if self.sorted_column >= 0:
-            self.filtered_dossiers.sort(
-                key=lambda x: list(x.values())[self.sorted_column],
-                reverse=self.sort_order == Qt.DescendingOrder
-            )
+        self.table.blockSignals(True)
+        try:
+            if self.sorted_column >= 0:
+                self.filtered_dossiers.sort(
+                    key=lambda x: list(x.values())[self.sorted_column],
+                    reverse=self.sort_order == Qt.DescendingOrder
+                )
 
-        self.table.setRowCount(len(self.filtered_dossiers))
+            self.table.setRowCount(len(self.filtered_dossiers))
 
-        for row, dossier in enumerate(self.filtered_dossiers):
-            self.table.setItem(row, 0, QTableWidgetItem(dossier["nom"]))
-            self.table.setItem(row, 1, QTableWidgetItem(dossier["type"]))
-            self.table.setItem(row, 2, QTableWidgetItem(dossier["date"]))
-            self.table.setItem(row, 3, QTableWidgetItem(dossier["paiement"]))
+            for row, dossier in enumerate(self.filtered_dossiers):
+                self.table.setItem(row, 0, QTableWidgetItem(dossier["nom"]))
+                self.table.setItem(row, 1, QTableWidgetItem(dossier["type"]))
+                self.table.setItem(row, 2, QTableWidgetItem(dossier["date"]))
+                self.table.setItem(row, 3, QTableWidgetItem(dossier["paiement"]))
 
-            assainissement = self.manual_states.get(dossier["nom"], {}).get("assainissement", "")
-            dossier_statut = self.manual_states.get(dossier["nom"], {}).get("dossier", "")
-            commentaire = self.manual_states.get(dossier["nom"], {}).get("commentaire", "")
+                assainissement = self.manual_states.get(dossier["nom"], {}).get("assainissement", "")
+                dossier_statut = self.manual_states.get(dossier["nom"], {}).get("dossier", "")
+                commentaire = self.manual_states.get(dossier["nom"], {}).get("commentaire", "")
 
-            self.table.setItem(row, 4, QTableWidgetItem(assainissement))
-            self.table.setItem(row, 5, QTableWidgetItem(dossier_statut))
-            self.table.setItem(row, 6, QTableWidgetItem(commentaire))
+                self.table.setItem(row, 4, QTableWidgetItem(assainissement))
+                self.table.setItem(row, 5, QTableWidgetItem(dossier_statut))
+                self.table.setItem(row, 6, QTableWidgetItem(commentaire))
+        finally:
+            self.table.blockSignals(False)
 
     def save_manual_states(self, item):
+        if self.table.signalsBlocked():
+            return
         row = item.row()
         col = item.column()
         if col >= 4:


### PR DESCRIPTION
## Summary
- prevent table refresh from triggering itemChanged by blocking signals
- ignore saves when updates are programmatic

## Testing
- `python -m py_compile main_suiviclientpro.py`


------
https://chatgpt.com/codex/tasks/task_e_688f991b8670832cac1664c838f7fb31