### PR TITLE
Fix Access dossier query and clean FicheClientWindow imports

### DIFF
--- a/main_suiviclientpro.py
+++ b/main_suiviclientpro.py
@@ -229,7 +229,6 @@ class SuiviClientPro(QMainWindow):
             dossier_data = self.get_dossier_data_from_row(row)
             print("Contenu du dossier sélectionné :", dossier_data)  # Déplacer ici
             if dossier_data:
-                from fiche_client_window import FicheClientWindow
                 fiche = FicheClientWindow(dossier_data, self)
                 fiche.exec_()
 
@@ -253,7 +252,7 @@ class SuiviClientPro(QMainWindow):
             # Requête pour récupérer toutes les données du dossier
             cursor.execute("""
                 SELECT *
-                FROM Dossiers
+                FROM Donnees_Dossiers
                 WHERE nom_dossier = ?
             """, (nom_dossier,))
 


### PR DESCRIPTION
## Summary
- query Donnees_Dossiers table for dossier details with standard SQL spacing
- remove redundant `FicheClientWindow` import from double-click handler

## Testing
- `python -m py_compile main_suiviclientpro.py config_window.py fiche_client_window.py`
- `pytest` *(no tests discovered)*
- attempted `pip install pyodbc` *(failed: Could not find a version that satisfies the requirement pyodbc)*

------
https://chatgpt.com/codex/tasks/task_e_688fd8e14ec8832c8b200320a3e2a820